### PR TITLE
Sample workaround to use encrypted shared prefs

### DIFF
--- a/sign-in-kotlin/app/build.gradle
+++ b/sign-in-kotlin/app/build.gradle
@@ -5,17 +5,17 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.3"
     defaultConfig {
         applicationId "com.okta.sample"
-        minSdkVersion 21
-        targetSdkVersion 29
+        minSdkVersion 23
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders = [
-                "appAuthRedirectScheme": "{customUriScheme}"
+                "appAuthRedirectScheme": "com.first.sample"
         ]
         if (project.rootProject.file('local.properties').exists()) {
             Properties properties = new Properties()
@@ -43,14 +43,17 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
-    implementation 'com.okta.android:oidc-androidx:1.0.16'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+    implementation 'com.okta.android:oidc-androidx:1.0.18'
     implementation 'com.okta.authn.sdk:okta-authn-sdk-api:2.0.0'
     implementation('com.okta.authn.sdk:okta-authn-sdk-impl:2.0.0') {
         exclude group: 'com.okta.sdk', module: 'okta-sdk-httpclient'
     }
 
-    implementation 'com.okta.sdk:okta-sdk-okhttp:2.0.0'
+    implementation ("com.okta.sdk:okta-sdk-okhttp:4.0.0") {
+        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+    }
+    implementation "com.squareup.okhttp3:okhttp:4.9.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
     implementation 'androidx.core:core-ktx:1.5.0-alpha04'
@@ -62,5 +65,6 @@ dependencies {
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'androidx.preference:preference-ktx:1.1.1'
+    implementation "androidx.security:security-crypto:1.1.0-alpha03"
 }

--- a/sign-in-kotlin/app/src/main/java/com/okta/sample/CombinedDefaultStorageAndEncryption.kt
+++ b/sign-in-kotlin/app/src/main/java/com/okta/sample/CombinedDefaultStorageAndEncryption.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License,
+ * Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.okta.sample
+
+import android.text.TextUtils
+import com.okta.oidc.storage.OktaStorage
+import com.okta.oidc.storage.SharedPreferenceStorage
+import com.okta.oidc.storage.security.DefaultEncryptionManager
+
+/**
+ * Combines DefaultEncryptionManager and SharedPreferenceStorage. This class is a combination of the
+ * SDK provided shared preference and encryption manager.
+ */
+class CombinedDefaultStorageAndEncryption(
+    private val sharedPreferenceStorage: SharedPreferenceStorage,
+    private val defaultEncryption: DefaultEncryptionManager,
+) : OktaStorage {
+
+    override fun save(key: String, value: String) {
+        // NO-OP do not use this to save.
+    }
+
+    override fun get(key: String): String? {
+        return sharedPreferenceStorage.get(defaultEncryption.getHashed(key))?.run {
+            defaultEncryption.decrypt(this)
+        }
+    }
+
+    override fun delete(key: String) {
+        sharedPreferenceStorage.delete(defaultEncryption.getHashed(key))
+    }
+}

--- a/sign-in-kotlin/app/src/main/java/com/okta/sample/EncryptedSharedPreferenceStorage.kt
+++ b/sign-in-kotlin/app/src/main/java/com/okta/sample/EncryptedSharedPreferenceStorage.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License,
+ * Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.okta.sample
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.SharedPreferences
+import android.text.TextUtils
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences.PrefKeyEncryptionScheme
+import androidx.security.crypto.EncryptedSharedPreferences.PrefValueEncryptionScheme.*
+import androidx.security.crypto.MasterKey
+import androidx.security.crypto.MasterKey.KeyScheme
+import androidx.security.crypto.MasterKeys
+import com.okta.oidc.storage.OktaStorage
+import com.okta.sample.EncryptedSharedPreferenceStorage
+
+class EncryptedSharedPreferenceStorage constructor(
+    context: Context,
+    masterKeyAlias: String,
+    prefsName: String,
+) : OktaStorage {
+    private val prefs: SharedPreferences
+
+    init {
+        val masterKey =
+            MasterKey.Builder(context, masterKeyAlias).setKeyScheme(KeyScheme.AES256_GCM).build()
+
+        prefs = EncryptedSharedPreferences.create(context,
+            prefsName,
+            masterKey,
+            PrefKeyEncryptionScheme.AES256_SIV,
+            AES256_GCM)
+    }
+
+    @SuppressLint("ApplySharedPref")
+    override fun save(key: String, value: String) {
+        prefs.edit().putString(key, value).commit()
+    }
+
+    override fun get(key: String): String? {
+        return prefs.getString(key, null)
+    }
+
+    @SuppressLint("ApplySharedPref")
+    override fun delete(key: String) {
+        prefs.edit().remove(key).commit()
+    }
+}

--- a/sign-in-kotlin/app/src/main/java/com/okta/sample/EncryptedStorage.kt
+++ b/sign-in-kotlin/app/src/main/java/com/okta/sample/EncryptedStorage.kt
@@ -1,0 +1,21 @@
+package com.okta.sample
+
+import com.okta.oidc.storage.OktaStorage
+import java.lang.Exception
+
+class EncryptedStorage(
+    private val combinedDefaultStorageAndEncryption: CombinedDefaultStorageAndEncryption,
+    private val encryptedSharedPreferenceStorage: EncryptedSharedPreferenceStorage,
+) : OktaStorage by encryptedSharedPreferenceStorage {
+
+    override fun get(key: String): String? {
+        return encryptedSharedPreferenceStorage.get(key) ?: run {
+            combinedDefaultStorageAndEncryption.get(key)
+        }
+    }
+
+    override fun delete(key: String) {
+        combinedDefaultStorageAndEncryption.delete(key)
+        encryptedSharedPreferenceStorage.delete(key)
+    }
+}

--- a/sign-in-kotlin/app/src/main/java/com/okta/sample/MainActivity.kt
+++ b/sign-in-kotlin/app/src/main/java/com/okta/sample/MainActivity.kt
@@ -44,6 +44,7 @@ import com.okta.oidc.clients.sessions.SessionClient
 import com.okta.oidc.clients.web.WebAuthClient
 import com.okta.oidc.results.Result
 import com.okta.oidc.storage.SharedPreferenceStorage
+import com.okta.oidc.storage.security.DefaultEncryptionManager
 import com.okta.oidc.util.AuthorizationException
 import com.okta.sample.BuildConfig.ORG_URL
 import kotlinx.android.synthetic.main.activity_main.*
@@ -152,10 +153,17 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
     }
 
     private fun createWebClient() {
+        val combinedStorage = CombinedDefaultStorageAndEncryption(SharedPreferenceStorage(this),
+            DefaultEncryptionManager(this))
+
+        val encryptedSharedPreferenceStorage =
+            EncryptedSharedPreferenceStorage(this, "MyMasterKeyAlias", "MyEncryptedSharedPrefs")
+
         webAuthClient = Okta.WebAuthBuilder()
             .withConfig(config)
             .withContext(this)
-            .withStorage(SharedPreferenceStorage(this, PREF_STORAGE_WEB))
+            .withEncryptionManager(NoEncryption())
+            .withStorage(EncryptedStorage(combinedStorage, encryptedSharedPreferenceStorage))
             .setRequireHardwareBackedKeyStore(hardwareKeystore)
             .create()
 

--- a/sign-in-kotlin/app/src/main/java/com/okta/sample/NoEncryption.kt
+++ b/sign-in-kotlin/app/src/main/java/com/okta/sample/NoEncryption.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License,
+ * Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.okta.sample
+
+import android.content.Context
+import com.okta.oidc.storage.security.EncryptionManager
+import java.io.UnsupportedEncodingException
+import java.security.GeneralSecurityException
+import java.security.NoSuchAlgorithmException
+import javax.crypto.Cipher
+
+/**
+ * A sample on how to disable encryption. Set this implementation in
+ */
+class NoEncryption : EncryptionManager {
+    @Throws(GeneralSecurityException::class)
+    override fun encrypt(value: String?): String? {
+        return value
+    }
+
+    @Throws(GeneralSecurityException::class)
+    override fun decrypt(value: String?): String? {
+        return value
+    }
+
+    @Throws(NoSuchAlgorithmException::class, UnsupportedEncodingException::class)
+    override fun getHashed(value: String?): String? {
+        return value
+    }
+
+    override fun isHardwareBackedKeyStore(): Boolean {
+        return true
+    }
+
+    override fun recreateCipher() {
+        //NO-OP
+    }
+
+    override fun setCipher(cipher: Cipher) {
+        //NO-OP
+    }
+
+    override fun getCipher(): Cipher? {
+        //NO-OP
+        return null
+    }
+
+    override fun removeKeys() {
+        //NO-OP
+    }
+
+    override fun recreateKeys(context: Context) {
+        //NO-OP
+    }
+
+    override fun isUserAuthenticatedOnDevice(): Boolean {
+        return true
+    }
+
+    override fun isValidKeys(): Boolean {
+        return true
+    }
+}

--- a/sign-in-kotlin/app/src/main/res/raw/config.json
+++ b/sign-in-kotlin/app/src/main/res/raw/config.json
@@ -1,11 +1,12 @@
 {
-  "client_id": "",
-  "redirect_uri": "",
-  "end_session_redirect_uri": "",
+  "client_id": "0oalpui4tcMY8u7RX0h7",
+  "redirect_uri": "com.first.sample:/callback",
+  "end_session_redirect_uri": "com.first.sample:/logout",
   "scopes": [
     "openid",
     "profile",
-    "offline_access",
+    "address",
+    "offline_access"
   ],
-  "discovery_uri": ""
+  "discovery_uri": "https://dev-486177.oktapreview.com/.well-known/openid-configuration"
 }

--- a/sign-in-kotlin/build.gradle
+++ b/sign-in-kotlin/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.0'
+    ext.kotlin_version = '1.5.0'
     repositories {
         google()
         jcenter()
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/sign-in-kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/sign-in-kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
If default encryption manager fails then use encrypted
shared prefs as backup.