### PR TITLE
replace globalScope with lifecycleScope

### DIFF
--- a/sign-in-kotlin/app/build.gradle
+++ b/sign-in-kotlin/app/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.0-beta01'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/sign-in-kotlin/app/src/main/java/com/okta/sample/MainActivity.kt
+++ b/sign-in-kotlin/app/src/main/java/com/okta/sample/MainActivity.kt
@@ -221,24 +221,23 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
     }
 
     private fun authenticateUser(username: String, password: String) {
-        GlobalScope.launch(Dispatchers.Main) {
-            withContext(Dispatchers.IO) {
-                authenticationClient.authenticate(
-                    username, password.toCharArray(),
-                    null, null
-                )
-            }?.run {
-                authClient.signIn(sessionToken, null, object :
-                    RequestCallback<Result, AuthorizationException> {
-                    override fun onSuccess(result: Result) {
-                        signInSuccess()
-                    }
+        lifecycleScope.launch(Dispatchers.IO) {
+            authenticationClient.authenticate(
+                username, password.toCharArray(),
+                null, null
+            )
+                .run {
+                    authClient.signIn(sessionToken, null, object :
+                        RequestCallback<Result, AuthorizationException> {
+                        override fun onSuccess(result: Result) {
+                            signInSuccess()
+                        }
 
-                    override fun onError(error: String?, exception: AuthorizationException?) {
-                        signInError(error, exception)
-                    }
-                })
-            }
+                        override fun onError(error: String?, exception: AuthorizationException?) {
+                            signInError(error, exception)
+                        }
+                    })
+                }
         }
     }
 


### PR DESCRIPTION
use lifecycle-aware component lifecycleScope instead of globalScope, will automatically release after activity destroy