### PR TITLE
Refactor totp sample update handling

### DIFF
--- a/totp/src/main/java/com/okta/totp/coroutine/ticker/TickerFlowFactory.kt
+++ b/totp/src/main/java/com/okta/totp/coroutine/ticker/TickerFlowFactory.kt
@@ -1,0 +1,8 @@
+package com.okta.totp.coroutine.ticker
+
+import kotlinx.coroutines.flow.Flow
+import kotlin.time.Duration
+
+fun interface TickerFlowFactory {
+    fun getTickerFlow(period: Duration, initialDelay: Duration): Flow<Unit>
+}

--- a/totp/src/main/java/com/okta/totp/coroutine/ticker/TickerFlowFactoryImpl.kt
+++ b/totp/src/main/java/com/okta/totp/coroutine/ticker/TickerFlowFactoryImpl.kt
@@ -1,0 +1,17 @@
+package com.okta.totp.coroutine.ticker
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+import kotlin.time.Duration
+
+class TickerFlowFactoryImpl @Inject constructor() : TickerFlowFactory {
+    override fun getTickerFlow(period: Duration, initialDelay: Duration): Flow<Unit> = flow {
+        delay(initialDelay)
+        while (true) {
+            emit(Unit)
+            delay(period)
+        }
+    }
+}

--- a/totp/src/main/java/com/okta/totp/coroutine/ticker/TickerFlowModule.kt
+++ b/totp/src/main/java/com/okta/totp/coroutine/ticker/TickerFlowModule.kt
@@ -1,0 +1,17 @@
+package com.okta.totp.coroutine.ticker
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+interface TickerFlowModule {
+    @Singleton
+    @Binds
+    fun bindTickerFlowFactory(
+        tickerFlowFactoryImpl: TickerFlowFactoryImpl
+    ): TickerFlowFactory
+}

--- a/totp/src/main/java/com/okta/totp/password_generator/PasswordGeneratorModule.kt
+++ b/totp/src/main/java/com/okta/totp/password_generator/PasswordGeneratorModule.kt
@@ -23,14 +23,14 @@ import dagger.hilt.components.SingletonComponent
 
 @InstallIn(SingletonComponent::class)
 @Module
-abstract class PasswordGeneratorModule {
+interface PasswordGeneratorModule {
     @Binds
-    abstract fun bindPasswordGenerator(
+    fun bindPasswordGenerator(
         passwordGenerator: PasswordGeneratorImpl
     ): PasswordGenerator
 
     @Binds
-    abstract fun bindPasswordGeneratorFactory(
+    fun bindPasswordGeneratorFactory(
         passwordGeneratorFactoryImpl: PasswordGeneratorFactoryImpl
     ): PasswordGeneratorFactory
 }

--- a/totp/src/main/java/com/okta/totp/time/TimeProviderModule.kt
+++ b/totp/src/main/java/com/okta/totp/time/TimeProviderModule.kt
@@ -23,9 +23,9 @@ import dagger.hilt.components.SingletonComponent
 
 @InstallIn(SingletonComponent::class)
 @Module
-abstract class TimeProviderModule {
+interface TimeProviderModule {
     @Binds
-    abstract fun bindTimeProvider(
+    fun bindTimeProvider(
         timeProviderImpl: TimeProviderImpl
     ) : TimeProvider
 }

--- a/totp/src/test/java/com/okta/totp/coroutine/CoroutineDispatcherRule.kt
+++ b/totp/src/test/java/com/okta/totp/coroutine/CoroutineDispatcherRule.kt
@@ -1,0 +1,23 @@
+package com.okta.totp.coroutine
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestRule
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CoroutineDispatcherRule : TestWatcher(), TestRule {
+    override fun starting(description: Description) {
+        super.starting(description)
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+
+    override fun finished(description: Description) {
+        super.finished(description)
+        Dispatchers.resetMain()
+    }
+}

--- a/totp/src/test/java/com/okta/totp/coroutine/ticker/TestTickerFlowFactory.kt
+++ b/totp/src/test/java/com/okta/totp/coroutine/ticker/TestTickerFlowFactory.kt
@@ -1,0 +1,16 @@
+package com.okta.totp.coroutine.ticker
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.take
+import kotlin.time.Duration
+
+internal class TestTickerFlowFactory(
+    private val maxUpdates: Int,
+) : TickerFlowFactory {
+
+    override fun getTickerFlow(period: Duration, initialDelay: Duration): Flow<Unit> {
+        if (maxUpdates == 0) return emptyFlow()
+        return TickerFlowFactoryImpl().getTickerFlow(period, initialDelay).take(maxUpdates)
+    }
+}


### PR DESCRIPTION
Previously, test-specific code was added to OtpDisplayViewModel to make it possible to unit test totp refresh behavior. This PR refactors that to remove all test specific code in OtpDisplayViewModel, and instead delegates update signals to TickerFlowFactory. Unit tests provide their own version of TickerFlowFactory for testing.