### PR TITLE
Use setup-gcloud github actions command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,12 +42,28 @@ jobs:
       - name: Run Tests
         run: ./gradlew assembleDebug testDebugUnitTest assembleAndroidTest
 
-      - name: Authenticate Gcloud command line
+      - name: Setup Gcloud credentials
         if: ${{ github.event.repository.fork == false }}
         env:
-          GOOGLE_PROJECT_ID: ${{ secrets.GOOGLE_PROJECT_ID }}
           GOOGLE_SERVICE_JSON_BASE64: ${{ secrets.GOOGLE_SERVICE_JSON_BASE64 }}
-        run: ./signInToGcloud.sh && source $HOME/google-cloud-sdk/path.bash.inc && export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+        run: |
+          echo "::add-mask::$(echo $GOOGLE_SERVICE_JSON_BASE64 | base64 --decode | jq -r tostring)"
+          echo "GOOGLE_SERVICE_JSON=$(echo $GOOGLE_SERVICE_JSON_BASE64 | base64 --decode | jq -r tostring)" >> $GITHUB_ENV
+
+      - name: Authenticate Gcloud command line
+        if: ${{ github.event.repository.fork == false }}
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ env.GOOGLE_SERVICE_JSON }}
+          project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
+
+      - name: Set up Cloud SDK
+        if: ${{ github.event.repository.fork == false }}
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Use gcloud CLI
+        if: ${{ github.event.repository.fork == false }}
+        run: gcloud auth list &> /dev/null
 
       - name: Run End to End Tests
         if: ${{ github.event.repository.fork == false }}

--- a/signInToGcloud.sh
+++ b/signInToGcloud.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-export CLOUDSDK_CORE_DISABLE_PROMPTS=1
-curl https://sdk.cloud.google.com | bash > /dev/null
-echo $GOOGLE_SERVICE_JSON_BASE64 | base64 --decode > client-secret.json
-gcloud auth activate-service-account --key-file client-secret.json
-source $HOME/google-cloud-sdk/path.bash.inc
-gcloud config set project $GOOGLE_PROJECT_ID
-gcloud auth list # This is necessary to trigger gcloud auth so that it doesn't error when accessing it in the test scripts.


### PR DESCRIPTION
This change replaces fetching gcloud sdk with google-github-actions/setup-gcloud. This should address security concerns with executing a bash script from a remote url.