### PR TITLE
Update xml libraries in instrumentation tests

### DIFF
--- a/browser-sign-in/build.gradle
+++ b/browser-sign-in/build.gradle
@@ -51,6 +51,15 @@ android {
 
         execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
+
+    packagingOptions {
+        resources {
+            excludes += '/META-INF/*'
+            excludes += 'draftv3/schema'
+            excludes += 'draftv4/schema'
+        }
+    }
+
     namespace 'com.okta.android.samples.browser_sign_in'
 }
 
@@ -73,7 +82,10 @@ dependencies {
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.jackson.dataformat.yml)
     androidTestImplementation(libs.bundles.android.instrumentation.testing)
-    androidTestImplementation(libs.bundles.okta.testing)
+    androidTestImplementation(libs.okta.management.sdk) {
+        exclude group: "javax.validation"
+        exclude group: "org.slf4j", module: "jcl-over-slf4j"
+    }
     androidTestUtil(libs.androidx.test.orchestrator)
     debugImplementation(libs.androidx.test.fragment) {
         transitive false

--- a/browser-sign-in/src/androidTest/java/com/okta/android/samples/browser_sign_in/test/TestClientBuilder.kt
+++ b/browser-sign-in/src/androidTest/java/com/okta/android/samples/browser_sign_in/test/TestClientBuilder.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.android.samples.browser_sign_in.test
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.okta.sdk.authc.credentials.ClientCredentials
+import com.okta.sdk.cache.Caches
+import com.okta.sdk.error.ErrorHandler
+import com.okta.sdk.impl.api.DefaultClientCredentialsResolver
+import com.okta.sdk.impl.client.DefaultClientBuilder
+import com.okta.sdk.impl.deserializer.UserProfileDeserializer
+import com.okta.sdk.impl.serializer.UserProfileSerializer
+import com.okta.sdk.impl.util.DefaultBaseUrlResolver
+import org.openapitools.client.ApiClient
+import org.openapitools.client.model.UserProfile
+import org.openapitools.jackson.nullable.JsonNullableModule
+import org.springframework.http.MediaType
+import org.springframework.http.client.OkHttp3ClientHttpRequestFactory
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.util.DefaultUriBuilderFactory
+import java.util.Arrays
+import java.util.concurrent.TimeUnit
+import kotlin.String
+
+internal class TestClientBuilder(
+    private val clientId: String,
+    private val orgUrl: String,
+    private val clientCredentials: ClientCredentials<*>
+) {
+    private val clientConfiguration = DefaultClientBuilder().clientConfiguration.apply {
+        baseUrl = orgUrl
+        clientId = this@TestClientBuilder.clientId
+    }
+
+    fun build(): ApiClient {
+        val cacheManager = Caches.newCacheManager()
+            .withDefaultTimeToIdle(clientConfiguration.cacheManagerTti, TimeUnit.SECONDS)
+            .withDefaultTimeToLive(clientConfiguration.cacheManagerTtl, TimeUnit.SECONDS)
+            .build()
+
+        clientConfiguration.baseUrlResolver = DefaultBaseUrlResolver(orgUrl)
+        val apiClient = ApiClient(
+            restTemplate(),
+            cacheManager,
+            clientConfiguration
+        )
+        apiClient.basePath = clientConfiguration.baseUrl
+        clientConfiguration.clientCredentialsResolver = DefaultClientCredentialsResolver(clientCredentials)
+        apiClient.setApiKeyPrefix("SSWS")
+        apiClient.setApiKey(clientCredentials.credentials as String)
+        return apiClient
+    }
+
+    private fun restTemplate(): RestTemplate {
+        val objectMapper = ObjectMapper()
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        objectMapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
+        objectMapper.registerModule(JavaTimeModule())
+        objectMapper.registerModule(JsonNullableModule())
+        val module = SimpleModule()
+        module.addSerializer(UserProfile::class.java, UserProfileSerializer())
+        module.addDeserializer(UserProfile::class.java, UserProfileDeserializer())
+        objectMapper.registerModule(module)
+        val mappingJackson2HttpMessageConverter = MappingJackson2HttpMessageConverter(objectMapper)
+        mappingJackson2HttpMessageConverter.supportedMediaTypes = Arrays.asList(
+            MediaType.APPLICATION_JSON,
+            MediaType.parseMediaType("application/x-pem-file"),
+            MediaType.parseMediaType("application/x-x509-ca-cert"),
+            MediaType.parseMediaType("application/pkix-cert")
+        )
+        val messageConverters: MutableList<HttpMessageConverter<*>> = ArrayList()
+        messageConverters.add(mappingJackson2HttpMessageConverter)
+        val restTemplate = RestTemplate(messageConverters)
+        restTemplate.errorHandler = ErrorHandler()
+        restTemplate.requestFactory = OkHttp3ClientHttpRequestFactory()
+        val uriTemplateHandler = DefaultUriBuilderFactory()
+        uriTemplateHandler.encodingMode = DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY
+        restTemplate.uriTemplateHandler = uriTemplateHandler
+        return restTemplate
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ security-crypto-stable = "1.0.0"
 security-crypto-ktx = "1.1.0-alpha03"
 androidx-biometrics = "1.1.0"
 
-okta-bom = "1.1.1"
+okta-bom = "1.1.3"
 
 kotlin-stdlib = "1.7.20"
 timber = "5.0.1"
@@ -43,7 +43,7 @@ commons-codec = "1.15"
 
 # Testing lib versions
 junit = "4.13.2"
-jackson = "2.14.0"
+jackson = "2.15.2"
 truth = "1.1.3"
 mockk = "1.13.2"
 androidx-test = "1.5.0"
@@ -54,8 +54,7 @@ androidx-test-ext = "1.1.4"
 androidx-test-fragment = "1.5.4"
 androidx-test-uiautomator = "2.2.0"
 robolectric = "4.9"
-okta-http-okhttp = "1.3.2"
-okta-management-sdk = "8.2.2"
+okta-management-sdk = "10.3.0"
 
 [libraries]
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
@@ -142,7 +141,6 @@ androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-
 androidx-test-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-test-uiautomator" }
 
 okta-management-sdk = { module = "com.okta.sdk:okta-sdk-impl", version.ref = "okta-management-sdk" }
-okta-http-okhttp = { module = "com.okta.commons:okta-http-okhttp", version.ref = "okta-http-okhttp" }
 
 [bundles]
 # Common android imports
@@ -202,8 +200,4 @@ android-instrumentation-testing = [
     "androidx-test-runner",
     "androidx-test-rules",
     "androidx-test-uiautomator",
-]
-okta-testing = [
-    "okta-management-sdk",
-    "okta-http-okhttp",
 ]


### PR DESCRIPTION
Vulnerable XML dependencies are pulled by jackson and okta management sdk. Updating management SDK breaks DefaultClientBuilder for Android. So, I also created TestClientBuilder to fix it for Android instrumentation tests.