### PR TITLE
fix: upgrade jackson-core to 2.19.0 (OKTA-1152396)

### DIFF
--- a/browser-sign-in/build.gradle
+++ b/browser-sign-in/build.gradle
@@ -92,6 +92,7 @@ dependencies {
     }
     constraints {
         androidTestImplementation(libs.bcpkix.jdk18on)
+        androidTestImplementation(libs.jackson.core)
     }
     androidTestUtil(libs.androidx.test.orchestrator)
     debugImplementation(libs.androidx.test.fragment) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ bcpkix-jdk18on = "1.84"
 
 # Testing lib versions
 junit = "4.13.2"
-jackson = "2.15.2"
+jackson = "2.19.0"
 truth = "1.1.3"
 mockk = "1.13.2"
 androidx-test = "1.5.0"
@@ -123,6 +123,7 @@ bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bc
 
 # Testing libs
 junit = { module = "junit:junit", version.ref = "junit" }
+jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-dataformat-yml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }


### PR DESCRIPTION
Upgrade jackson version from 2.15.2 to 2.19.0 to address SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551 (Allocation of Resources Without Limits or Throttling, CVSS 8.7).

Add jackson-core constraint in browser-sign-in/build.gradle to force the upgraded version for all transitive paths through okta-sdk-impl.

RESOLVES: OKTA-1152396